### PR TITLE
RGB888 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ If you need to use RGB565 (16-bit color) mode for bandwidth savings or compatibi
 
 **Important:** On Tanmatsu devices, `st7701_initialize()` is called internally by `bsp_device_initialize()`. You must call `st7701_set_color_format()` **before** `bsp_device_initialize()` to ensure the display controller is configured correctly from the start.
 
+#### Setup
+
+First, add the component dependency to your `main/CMakeLists.txt`:
+
+```cmake
+idf_component_register(
+    SRCS "main.c"
+    PRIV_REQUIRES
+        badge-bsp
+        esp32-component-mipi-dsi-abstraction  # Add this line
+    INCLUDE_DIRS "."
+)
+```
+
 #### Usage Example:
 
 ```c
@@ -61,7 +75,9 @@ void app_main(void) {
 }
 ```
 
-**Note:** The `extern` declaration is necessary because `st7701_set_color_format()` is not exposed through the BSP headers. Alternatively, you can include `"dsi_panel_nicolaielectronics_st7701.h"` directly if your build system has access to the component headers.
+**Notes:**
+- The `extern` declaration is necessary because `st7701_set_color_format()` is not exposed through the BSP headers.
+- Adding `esp32-component-mipi-dsi-abstraction` to `PRIV_REQUIRES` is required for the linker to find the function.
 
 ### Color Format Comparison
 

--- a/dsi_panel_nicolaielectronics_st7701.c
+++ b/dsi_panel_nicolaielectronics_st7701.c
@@ -22,7 +22,7 @@
 
 static const char* TAG = "ST7701 panel";
 
-// FPS = 30000000/(40+40+30+480)/(16+16+16+800) = 60Hz
+// FPS = 30000000/(40+40+30+480)/(16+16+2+800) = 60.9Hz (VFP=2 for this panel)
 #define PANEL_MIPI_DSI_DPI_CLK_MHZ 30
 #define PANEL_MIPI_DSI_LCD_H_RES   480
 #define PANEL_MIPI_DSI_LCD_V_RES   800
@@ -41,6 +41,7 @@ static const st7701_lcd_init_cmd_t tanmatsu_display_init_sequence[] = {
     {0xFF, (uint8_t[]){0x77, 0x01, 0x00, 0x00, 0x00}, 5, 0},  // Regular command function
     {LCD_CMD_NORON, (uint8_t[]){0x00}, 0, 0},                 // Turn on normal display mode
     {0xEF, (uint8_t[]){0x08}, 1, 0},                          //
+    {LCD_CMD_COLMOD, (uint8_t[]){0x77}, 1, 0},                // 24BPP: Set RGB888 pixel format (0x77 = 24-bit)
 
     {0xFF, (uint8_t[]){0x77, 0x01, 0x00, 0x00, 0x10}, 5, 0},  // Command 2 BK0 function
     {0xC0, (uint8_t[]){0x63, 0x00}, 2, 0},                    // LNESET (Display Line Setting): (0x63+1)*8 = 800 lines
@@ -104,7 +105,7 @@ esp_err_t st7701_get_parameters(size_t* h_res, size_t* v_res, lcd_color_rgb_pixe
         *v_res = PANEL_MIPI_DSI_LCD_V_RES;
     }
     if (color_fmt) {
-        *color_fmt = LCD_COLOR_PIXEL_FORMAT_RGB565;
+        *color_fmt = LCD_COLOR_PIXEL_FORMAT_RGB888;  // 24BPP: Changed from RGB565
     }
 
     return ESP_OK;
@@ -135,7 +136,7 @@ esp_err_t st7701_initialize(gpio_num_t reset_pin) {
         .virtual_channel = 0,
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,
         .dpi_clock_freq_mhz = PANEL_MIPI_DSI_DPI_CLK_MHZ,
-        .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565,
+        .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB888,  // 24BPP: Changed from RGB565
         .video_timing =
             {
                 .h_size = PANEL_MIPI_DSI_LCD_H_RES,
@@ -164,7 +165,7 @@ esp_err_t st7701_initialize(gpio_num_t reset_pin) {
     esp_lcd_panel_dev_config_t lcd_dev_config = {
         .reset_gpio_num = reset_pin,
         .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,
-        .bits_per_pixel = 16,
+        .bits_per_pixel = 24,  // 24BPP: Changed from 16
         .vendor_config = &vendor_config,
     };
     ESP_ERROR_CHECK(esp_lcd_new_panel_st7701(mipi_dbi_io, &lcd_dev_config, &mipi_dpi_panel));

--- a/include/dsi_panel_nicolaielectronics_st7701.h
+++ b/include/dsi_panel_nicolaielectronics_st7701.h
@@ -11,3 +11,4 @@ esp_lcd_panel_handle_t st7701_get_panel(void);
 esp_lcd_panel_io_handle_t st7701_get_panel_io(void);
 esp_err_t st7701_initialize(gpio_num_t reset_pin);
 esp_err_t st7701_get_parameters(size_t* h_res, size_t* v_res, lcd_color_rgb_pixel_format_t* color_fmt);
+esp_err_t st7701_set_color_format(lcd_color_rgb_pixel_format_t format);


### PR DESCRIPTION
This adds RGB888 / 24BPP support for the Tanmatsu as default, with the option to switch back to RGB565 / 16BPP mode for speed and backbwards compatibility